### PR TITLE
Ripristino route FIDO2 e migliorie demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+NEXT_PUBLIC_SITE_URL=https://your-site.vercel.app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env.local
+.env.*.local
+.DS_Store
+next-env.d.ts
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Demo completo per l'autenticazione passwordless tramite **FIDO2/WebAuthn**, inte
 ├── public/
 │   └── logo.svg                        # Logo personalizzato
 ├── README.md
-└── .env.local                          # Variabili ambiente
+├── .env.local                          # Variabili ambiente
+└── .env.example                        # Esempio configurazione
 ```
 
 ## 🔧 Variabili ambiente richieste
@@ -38,6 +39,9 @@ NEXT_PUBLIC_SUPABASE_URL=https://<your-project>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
 NEXT_PUBLIC_SITE_URL=https://<your-site>.vercel.app
 ```
+
+Copiate il file `.env.example` in `.env.local` e sostituite i valori con le
+credenziali del vostro progetto Supabase e l'URL del sito.
 
 ## 🧱 Supabase Schema SQL
 

--- a/app/api/generate-authentication-options/route.ts
+++ b/app/api/generate-authentication-options/route.ts
@@ -1,1 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { generateAuthenticationOptionsForUser } from '@/lib/webauthn';
+import { getUserByEmail } from '@/lib/supabaseClient';
+import challengeStore from '@/lib/challengeStore';
 
+export async function POST(request: NextRequest) {
+  try {
+    const { email } = await request.json();
+
+    let allowCredentials: any[] = [];
+
+    if (email) {
+      // Login con email specifica
+      const user = await getUserByEmail(email);
+      if (!user) {
+        return NextResponse.json(
+          { error: 'User not found' },
+          { status: 404 }
+        );
+      }
+
+      allowCredentials = [{
+        id: user.credential_id,
+        type: 'public-key' as const,
+        transports: user.transports ? JSON.parse(user.transports) as AuthenticatorTransport[] : undefined,
+      }];
+    }
+
+    // Genera le opzioni di autenticazione
+    const options = await generateAuthenticationOptionsForUser(allowCredentials);
+
+    // Memorizza la challenge
+    const challengeKey = email || 'anonymous';
+    challengeStore.store(challengeKey, options.challenge);
+
+    return NextResponse.json(options);
+
+  } catch (error) {
+    console.error('Generate authentication options error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -22,7 +22,7 @@ export interface DatabaseUser {
   credential_id: string;
   public_key: string;
   counter: number;
-  transports?: AuthenticatorTransport[];
+  transports?: string | null;
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## Summary
- restore `generate-authentication-options` API route
- add `.gitignore` and `.env.example`
- document environment variables in README
- fix database user type for transports

## Testing
- `npm run build` *(fails: Missing Supabase env variables)*

------
https://chatgpt.com/codex/tasks/task_e_688c64815784832b8438448793b09b6f