### PR TITLE
Handle verify response during registration

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -14,12 +14,16 @@ export default function RegisterPage() {
 
     const credential = await startRegistration(options);
 
-    await fetch('/api/verify-registration', {
+    const verify = await fetch('/api/verify-registration', {
       method: 'POST',
-      body: JSON.stringify({ credential, email }),
+      body: JSON.stringify({ response: credential, email }),
     });
 
-    alert('Registrazione completata!');
+    if ((await verify.json()).verified) {
+      alert('Registrazione completata!');
+    } else {
+      alert('Errore nella registrazione.');
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- send `response` and email when verifying registration
- alert only when the server reports verified, otherwise show an error

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688e2f66e03c832bb1a9c8097a0f32fb