### PR TITLE
Send login assertion as response for authentication

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -16,7 +16,7 @@ export default function LoginPage() {
 
     const verify = await fetch('/api/verify-authentication', {
       method: 'POST',
-      body: JSON.stringify({ assertion, email }),
+      body: JSON.stringify({ response: assertion, email }),
     });
 
     if ((await verify.json()).verified) {


### PR DESCRIPTION
## Summary
- Send login assertion under `response` key to align with `/api/verify-authentication` expectations.
- Confirm `/api/verify-authentication` extracts the `response` object when validating login.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688e2f548b50832bb339f0bb059c0dcd