### PR TITLE
fix: declare AuthenticatorTransport type in auth options route

### DIFF
--- a/app/api/generate-authentication-options/route.ts
+++ b/app/api/generate-authentication-options/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { generateAuthenticationOptionsForUser } from '@/lib/webauthn';
 import { getUserByEmail } from '@/lib/supabaseClient';
 import challengeStore from '@/lib/challengeStore';
+import type { AuthenticatorTransport } from '@simplewebauthn/types';
 
 export async function POST(request: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- import AuthenticatorTransport type for generating auth options API

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Missing Supabase environment variables)


------
https://chatgpt.com/codex/tasks/task_e_688e2f6e3cf4832b937c1df865cf2ebb