### PR TITLE
Refactor login verification handling

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -19,7 +19,9 @@ export default function LoginPage() {
       body: JSON.stringify({ response: assertion, email }),
     });
 
-    if ((await verify.json()).verified) {
+    const verificationJSON = await verify.json();
+
+    if (verificationJSON.verified) {
       alert('Login completato!');
     } else {
       alert('Errore di autenticazione.');


### PR DESCRIPTION
## Summary
- parse verification response JSON before checking success
- login verification request retains `response` with assertion

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_688e3c3fe120832b956f183cd6554a2a