### PR TITLE
Gestisci utente assente e suggerisci registrazione

### DIFF
--- a/app/api/generate-authentication-options/route.ts
+++ b/app/api/generate-authentication-options/route.ts
@@ -14,7 +14,11 @@ export async function POST(request: NextRequest) {
       const user = await getUserByEmail(email);
       if (!user) {
         return NextResponse.json(
-          { error: 'User not found' },
+          {
+            error: 'User not found',
+            message: 'User not found. Please register to continue.',
+            signupUrl: '/register',
+          },
           { status: 404 }
         );
       }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -12,8 +12,24 @@ export default function LoginPage() {
         body: JSON.stringify({ email }),
       });
       if (!res.ok) {
-        const errText = await res.text();
-        alert(`Errore nella generazione delle opzioni: ${errText}`);
+        try {
+          const errorData = await res.json();
+          if (errorData?.error === 'User not found') {
+            const msg = 'Utente non trovato. Vuoi registrarti?';
+            if (errorData?.signupUrl && window.confirm(msg)) {
+              window.location.href = errorData.signupUrl;
+            } else {
+              alert('Utente non trovato. Registrati per continuare.');
+            }
+          } else {
+            alert(
+              `Errore nella generazione delle opzioni: ${errorData?.error || 'errore sconosciuto'}`
+            );
+          }
+        } catch {
+          const errText = await res.text();
+          alert(`Errore nella generazione delle opzioni: ${errText}`);
+        }
         return;
       }
       const options = await res.json();


### PR DESCRIPTION
## Summary
- Suggerisce la registrazione quando l'utente non esiste
- Avvisa l'utente nel login e permette la redirezione alla pagina di signup

## Testing
- `npm test` (missing script: test)
- `npm run lint` (prompt per configurazione ESLint)
- `npm run build` (Missing Supabase environment variables)


------
https://chatgpt.com/codex/tasks/task_e_688e4beb5ac0832bb3b6502db76a730b